### PR TITLE
fix: "toolbar-clipping enable"&"tone mapping option" flush when loading example

### DIFF
--- a/src/app/components/dialog/dialog.component.html
+++ b/src/app/components/dialog/dialog.component.html
@@ -214,12 +214,13 @@
                 <div class="param">
                     <div class="label">Tone mapping</div>
                     <div class="inputs">
-                        <select name="toneMapping" (change)="OnToneMappingChange($event)">
-                            <option value="noToneMapping" selected>Нет</option>
-                            <option value="linear">Линейный</option>
-                            <option value="Reinhard">Reinhard</option>
-                            <option value="Cineon">Cineon</option>
-                            <option value="ACESFilmic">ACESFilmic</option>
+                        <select name="toneMapping" (change)="OnToneMappingChange($event)"
+                            [ngModel]="SceneUtilsService.renderer.toneMapping.toString()">
+                            <option value="0" selected>None</option>
+                            <option value="1">Linear</option>
+                            <option value="2">Reinhard</option>
+                            <option value="3">Cineon</option>
+                            <option value="4">ACESFilmic</option>
                         </select>
                     </div>
                 </div>

--- a/src/app/components/dialog/dialog.component.ts
+++ b/src/app/components/dialog/dialog.component.ts
@@ -279,19 +279,19 @@ export class DialogComponent implements OnInit, OnChanges {
   OnToneMappingChange(event: Event) {
     let value = (event.target as any).value;
     switch (value) {
-      case "noToneMapping":
+      case "0":
         this.SceneUtilsService.renderer.toneMapping = THREE.NoToneMapping;
         break;
-      case "linear":
+      case "1":
         this.SceneUtilsService.renderer.toneMapping = THREE.LinearToneMapping;
         break;
-      case "Reinhard":
+      case "2":
         this.SceneUtilsService.renderer.toneMapping = THREE.ReinhardToneMapping;
         break;
-      case "Cineon":
+      case "3":
         this.SceneUtilsService.renderer.toneMapping = THREE.CineonToneMapping;
         break;
-      case "ACESFilmic":
+      case "4":
         this.SceneUtilsService.renderer.toneMapping = THREE.ACESFilmicToneMapping;
         break;
     }

--- a/src/app/components/menubar/menubar.component.html
+++ b/src/app/components/menubar/menubar.component.html
@@ -211,7 +211,7 @@
         <div class="vert-separator"></div>
         <div class="toolbar-tool"
             [ngStyle]="SceneUtilsService.SetDisableStyle(SceneUtilsService.model!=undefined && SceneUtilsService.model.children.length!=0)">
-            <input class="checkbox" type="checkbox" id="cut" (change)="SetClipping($event)">
+            <input #checkboxCutEnable class="checkbox" type="checkbox" id="cut" (change)="SetClipping($event)">
             <label for="cut"><img src="../../../assets/cut.png" width="19px" height="19px"
                     title="Включить разрез"></label>
         </div>

--- a/src/app/components/menubar/menubar.component.ts
+++ b/src/app/components/menubar/menubar.component.ts
@@ -12,6 +12,7 @@ import THREE = require('three');
 export class MenubarComponent implements AfterViewInit {
   posX = 0;
   posY = 0;
+  @ViewChild('checkboxCutEnable') checkboxCutEnableRef!: ElementRef;
   @ViewChild('file') fileRef!: ElementRef;
   get file(): HTMLCanvasElement {
     return this.fileRef.nativeElement;
@@ -28,6 +29,7 @@ export class MenubarComponent implements AfterViewInit {
   }
 
   async LoadExample(type: number) {
+    this.checkboxCutEnableRef.nativeElement.checked = true;//change toolbar status
     this.SceneUtilsService.EnableClipping(true);
     this.SceneUtilsService.renderer.toneMapping = THREE.ACESFilmicToneMapping;
     switch (type) {


### PR DESCRIPTION
When loading example, tone mapping is set to ACESF. The _tone mapping_ option should change simultaneously.
When loading example, clipping is enabled. The _toolbar-clipping enable_ status should change simultaneously.